### PR TITLE
Adds teachers field to the "Lesson" resource

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -320,6 +320,10 @@ pub struct Lesson {
     #[serde(rename = "ro")]
     pub rooms: Vec<IdItem>,
 
+    /// The teachers which are teaching this lesson.
+    #[serde(rename = "te")]
+    pub teachers: Vec<IdItem>,
+
     #[serde(default)]
     pub statflags: String,
 


### PR DESCRIPTION
Adds the missing teachers field in the Lesson struct. 
Without this the timetable is missing information about which teacher is holding which lesson.