### PR TITLE
fix: deserialization of ElementType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ chrono = "0.4"
 reqwest = { version = "0.12", features = ["cookies", "json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_repr = "0.1.19"

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,9 +1,10 @@
 use crate::datetime::{Date, Time};
 use serde::{Deserialize, Serialize};
+use serde_repr::*;
 use std::collections::HashMap;
 
 /// The different types of elements that exist in the Untis API.
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(u8)]
 pub enum ElementType {
     Class = 1,


### PR DESCRIPTION
Without this you get this error when creating client (client_login):

`Error: Serde(Error("data did not match any variant of untagged enum Response", line: 0, column: 0))`
