### PR TITLE
fix(Lesson): teachers are optional

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -321,7 +321,7 @@ pub struct Lesson {
     pub rooms: Vec<IdItem>,
 
     /// The teachers which are teaching this lesson.
-    #[serde(rename = "te")]
+    #[serde(rename = "te", default)]
     pub teachers: Vec<IdItem>,
 
     #[serde(default)]


### PR DESCRIPTION
fixes #10

Looks like our school doesn't associate lessons with teachers, as they're not added.
